### PR TITLE
Allow modification of countdown to !closebet when bet is open

### DIFF
--- a/pajbot/modules/dotabet.py
+++ b/pajbot/modules/dotabet.py
@@ -331,7 +331,7 @@ class DotaBetModule(BaseModule):
             count_down = 15
             if message and message.isdigit():
                 count_down = int(message)
-            if count_down != 0:
+            if count_down > 0:
                 bot.me('Betting will be locked in {} seconds! Place your bets people monkaS'.format(count_down))
             bot.execute_delayed(count_down, self.lock_bets, (bot,))
         elif message:


### PR DESCRIPTION
Inspired by bulldog's Sekiro run.
If the bet is lost while the bet is open, "!closebet lose" must be inputted 15 seconds after "!closebet" is inputted.
"!closebet (integer)" now allow mods to modify the countdown timer when locking down open bet.

Possible modification ideas:
1. separate command for locking bet and closing bet i.e. "!lockbet (integer)"
2. "!closebet (win/lose)" should immediately lock down and close opening bet instead of "!closebet 0" & "!closebet (win/lose)"