### PR TITLE
Test formatted thousand separator for givepoints

### DIFF
--- a/pajbot/modules/givepoints.py
+++ b/pajbot/modules/givepoints.py
@@ -114,13 +114,13 @@ class GivePointsModule(BaseModule):
 
             bot.whisper(
                 source.username,
-                "Successfully gave away {num_points} points to {target.username_raw}".format(
+                "Successfully gave away {num_points:,} points to {target.username_raw}".format(
                     num_points=num_points, target=target
                 ),
             )
             bot.whisper(
                 target.username,
-                "{source.username_raw} just gave you {num_points} points! You should probably thank them ;-)".format(
+                "{source.username_raw} just gave you {num_points:,} points! You should probably thank them ;-)".format(
                     num_points=num_points, source=source
                 ),
             )

--- a/pajbot/modules/subalert.py
+++ b/pajbot/modules/subalert.py
@@ -138,7 +138,7 @@ class SubAlertModule(BaseModule):
 
         user.points += self.settings["grant_points_on_sub"]
         self.bot.say(
-            "{} was given {} points for subscribing! FeelsAmazingMan".format(
+            "{} was given {:,} points for subscribing! FeelsAmazingMan".format(
                 user.username_raw, self.settings["grant_points_on_sub"]
             )
         )
@@ -328,7 +328,7 @@ class SubAlertModule(BaseModule):
                 addPoints = int(addPoints * ((0.025 * subMonths) + 1))
             source.points += addPoints
             self.bot.say(
-                "{} has been given {} points for {}sebbin {}FreakinStinkin".format(
+                "{} has been given {:,} points for {}sebbin {}FreakinStinkin".format(
                     source.username, addPoints, tierSub, monthText
                 )
             )

--- a/pajbot/modules/top.py
+++ b/pajbot/modules/top.py
@@ -114,7 +114,7 @@ class TopModule(BaseModule):
         data = []
         with DBManager.create_session_scope() as db_session:
             for user in db_session.query(User).order_by(User.points.desc())[: self.settings["num_top"]]:
-                data.append("{user.username_raw} ({user.points})".format(user=user))
+                data.append("{} ({:,})".format(user.username_raw, int(user.points)))
 
         bot.say("Top {num_top} banks: {data}".format(num_top=self.settings["num_top"], data=", ".join(data)))
 

--- a/pajbot/modules/viewerpoints.py
+++ b/pajbot/modules/viewerpoints.py
@@ -89,7 +89,7 @@ class MassPointsModule(BaseModule):
                         userInstance.points += givePoints
 
         bot.say(
-            "{} just gave {} viewers {} points each! Enjoy FeelsGoodMan".format(
+            "{} just gave {} viewers {:,} points each! Enjoy FeelsGoodMan".format(
                 source.username_raw, numUsers, givePoints
             )
         )


### PR DESCRIPTION
Change for example 

- [x] Givepoints module change from:

    > Successfully gave away 4444 points to Datguy1

    into 

    > Successfully gave away 4,444 points to Datguy1

- [x] Subalert module change from:

    > Datguy1 was given 2500 points for subscribing! FeelsAmazingMan

    into 

    > Datguy1 was given 2,500 points for subscribing! FeelsAmazingMan

- [x] Tiersub msg for Subalert module change from:

    > Datguy1 has been given 25000 points for Mega sebbin 100years FreakinStinkin

    into 

    > Datguy1 has been given 25,000 points for Mega sebbin 100years FreakinStinkin

- [x] Toppoints command from top module change from:

    > Top 5 banks: buttersomg (2179432), dinoxd (1492023), topramens (997673), batangquiapo1 (621665), izathelios (438480) 

    into 

    > Top 5 banks: buttersomg (2,179,432), dinoxd (1,492,023), topramens (997,673), batangquiapo1 (621,665), izathelios (438,480) 


Cant really test for !points, too lazy setup db and not really understand the workflow for this without actually setup the db xD but if you prefer for [this module](https://github.com/admiralbullbot/bullbot/blob/b6ef96f61678fab4a245d8ccddf9d1ae7aae9fee/pajbot/models/user.py#L211) 
```
@property 
    def get_points_str(self): 
        self.sql_load() 
        return format(self.user_model.points, ",") 
```
and change the !points command into
`$(usersource;1:username_raw) has $(usersource;1:get_points_str) points
`

The other module that manually change should work properly because its only format change.